### PR TITLE
Add AS5600 (hardware) encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ firmware/tinyg/default/path
 firmware/tinyg/Release/Makefile
 firmware/tinyg/Release/makedep.mk
 firmware/tinyg/default/path
+build
 tinyg.hex

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,8 @@
             "name": "Linux",
             "includePath": [
                 "${workspaceFolder}/**",
-                "/usr/include/**"
+                "/usr/lib/avr/include/**",
+                "/usr/lib/gcc/avr/5.4.0/include/**"
             ],
             "defines": [
                 "__AVR",
@@ -16,9 +17,9 @@
             "cStandard": "c17",
             "intelliSenseMode": "linux-gcc-x64",
             "compilerArgs": [
-                "-mmcu=atmega192a3",     // Will ensure MCU defines are set correctly
-                "-DF_CPU=16000000UL",   // Will ensure F_CPU is set correctly
-                "-Os"                   // Will avoid optimization warnings re: _delay
+                "-mmcu=atmega192a3",
+                "-DF_CPU=16000000UL",
+                "-Os"
             ]
         },
         {
@@ -40,9 +41,9 @@
             "cStandard": "c17",
             "intelliSenseMode": "linux-gcc-x64",
             "compilerArgs": [
-                "-mmcu=atmega192a3",     // Will ensure MCU defines are set correctly
-                "-DF_CPU=16000000UL",   // Will ensure F_CPU is set correctly
-                "-Os"                   // Will avoid optimization warnings re: _delay
+                "-mmcu=atmega192a3",
+                "-DF_CPU=16000000UL",
+                "-Os"
             ]
         }
     ],

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,6 +1,27 @@
 {
     "configurations": [
         {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/usr/include/**"
+            ],
+            "defines": [
+                "__AVR",
+                "__DOXYGEN__",
+                "__AVR_ATxmega192A3__",
+                "AS_5600_ENCODER"
+            ],
+            "compilerPath": "/usr/bin/avr-gcc",
+            "cStandard": "c17",
+            "intelliSenseMode": "linux-gcc-x64",
+            "compilerArgs": [
+                "-mmcu=atmega192a3",     // Will ensure MCU defines are set correctly
+                "-DF_CPU=16000000UL",   // Will ensure F_CPU is set correctly
+                "-Os"                   // Will avoid optimization warnings re: _delay
+            ]
+        },
+        {
             "name": "Mac",
             "includePath": [
                 "${workspaceFolder}/**",

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,14 +3,26 @@
         {
             "name": "Mac",
             "includePath": [
-                "${workspaceFolder}/**"
+                "${workspaceFolder}/**",
+                "/opt/homebrew/Cellar/avr-gcc@12/12.2.0_2/avr/include/**"
             ],
-            "defines": [],
+            "defines": [
+                "__AVR",
+                "__DOXYGEN__",
+                "__AVR_ATxmega192A3__",
+                "AS_5600_ENCODER"
+            ],
             "macFrameworkPath": [
                 "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
             ],
             "compilerPath": "/opt/homebrew/opt/avr-gcc@12/bin/avr-gcc",
-            "cStandard": "c17"
+            "cStandard": "c17",
+            "intelliSenseMode": "linux-gcc-x64",
+            "compilerArgs": [
+                "-mmcu=atmega192a3",     // Will ensure MCU defines are set correctly
+                "-DF_CPU=16000000UL",   // Will ensure F_CPU is set correctly
+                "-Os"                   // Will avoid optimization warnings re: _delay
+            ]
         }
     ],
     "version": 4

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "macFrameworkPath": [
+                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
+            ],
+            "compilerPath": "/opt/homebrew/opt/avr-gcc@12/bin/avr-gcc",
+            "cStandard": "c17"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
     "files.associations": {
         "tinyg.h": "c",
-        "xio.h": "c"
+        "xio.h": "c",
+        "encoder.h": "c"
     },
     "cmake.sourceDirectory": "/home/rvalls/dev/personal/TinyG-openpnp/firmware/tinyg"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "tinyg.h": "c"
+    },
+    "cmake.sourceDirectory": "${workspaceFolder}/firmware/tinyg"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,5 @@
         "tinyg.h": "c",
         "xio.h": "c"
     },
-    "cmake.sourceDirectory": "${workspaceFolder}/firmware/tinyg"
+    "cmake.sourceDirectory": "/home/rvalls/dev/personal/TinyG-openpnp/firmware/tinyg"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
-        "tinyg.h": "c"
+        "tinyg.h": "c",
+        "xio.h": "c"
     },
     "cmake.sourceDirectory": "${workspaceFolder}/firmware/tinyg"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cmake",
+			"label": "CMake: build",
+			"command": "build",
+			"targets": [
+				"all"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": [],
+			"detail": "CMake template build task"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "type": "pickString", 
             "id": "makeTarget", "description": "Select a build target", 
             "options": [
-                "make -j $(nprocs)", "sudo make flash", "make disassemble", "make squeaky_clean", "make size", "make debug",
+                "make -j $(nprocs)"
             ],
             "default": "make -j $(nprocs)"
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,8 +12,20 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"problemMatcher": [],
+			"problemMatcher": [
+				"$gcc"
+			],
 			"detail": "CMake template build task"
 		}
+	],
+    "inputs": [
+        { 
+            "type": "pickString", 
+            "id": "makeTarget", "description": "Select a build target", 
+            "options": [
+                "make -j $(nprocs)", "sudo make flash", "make disassemble", "make squeaky_clean", "make size", "make debug",
+            ],
+            "default": "make -j $(nprocs)"
+        }
 	]
 }

--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -17,5 +17,6 @@
 *.srec
 *.aws
 *.atsuo
+build
 .DS_Store
 TcfTransactionLog.csv

--- a/firmware/tinyg/.gitignore
+++ b/firmware/tinyg/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode/

--- a/firmware/tinyg/.gitignore
+++ b/firmware/tinyg/.gitignore
@@ -1,2 +1,1 @@
-build/
 .vscode/

--- a/firmware/tinyg/CMakeLists.txt
+++ b/firmware/tinyg/CMakeLists.txt
@@ -1,14 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 
-# https://stackoverflow.com/questions/54482519/avoid-cmake-to-add-the-flags-search-paths-first-and-headerpad-max-install-name
 set(HAVE_FLAG_SEARCH_PATHS_FIRST 0)
 project(tinyg VERSION 0.1.0)
 
-# https://gitlab.kitware.com/cmake/cmake/-/issues/24599
 unset(_CMAKE_APPLE_ARCHS_DEFAULT)
-#set(CMAKE_C_COMPILER_TARGET atxmega192a3)
-#set(CMAKE_SYSTEM_PROCESSOR ARM)
-#set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_C_COMPILER avr-gcc)
 
 add_executable(tinyg.elf

--- a/firmware/tinyg/CMakeLists.txt
+++ b/firmware/tinyg/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(tinyg.elf
     cycle_jogging.c
     cycle_probing.c
     encoder.c
+    encoder_as5600.c
     gcode_parser.c
     gpio.c
     hardware.c
@@ -54,6 +55,7 @@ add_executable(tinyg.elf
     xmega/xmega_init.c
     xmega/xmega_interrupts.c
     xmega/xmega_rtc.c
+    xmega/xmega_twi.c
 )
 
 target_compile_definitions(tinyg.elf PRIVATE

--- a/firmware/tinyg/CMakeLists.txt
+++ b/firmware/tinyg/CMakeLists.txt
@@ -82,10 +82,12 @@ target_compile_options(tinyg.elf PRIVATE
 )
 
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER 12.0)
-    message(STATUS "Addding workaround for avr-gcc 12 bug")
-    target_compile_options(tinyg.elf PRIVATE
-        --param=min-pagesize=0
-    )
+    if (CMAKE_C_COMPILER_VERSION VERSION_LESS_EQUAL 13.0)
+        message(STATUS "Addding workaround for avr-gcc 12 bug")
+        target_compile_options(tinyg.elf PRIVATE
+            --param=min-pagesize=0
+        )
+    endif()
 endif()
 
 target_link_options(tinyg.elf PRIVATE -mmcu=atxmega192a3)

--- a/firmware/tinyg/CMakeLists.txt
+++ b/firmware/tinyg/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 3.10)
+
+# https://stackoverflow.com/questions/54482519/avoid-cmake-to-add-the-flags-search-paths-first-and-headerpad-max-install-name
+set(HAVE_FLAG_SEARCH_PATHS_FIRST 0)
 project(tinyg VERSION 0.1.0)
 
-set(CMAKE_SYSTEM_NAME Generic)
+# https://gitlab.kitware.com/cmake/cmake/-/issues/24599
+unset(_CMAKE_APPLE_ARCHS_DEFAULT)
+#set(CMAKE_C_COMPILER_TARGET atxmega192a3)
+#set(CMAKE_SYSTEM_PROCESSOR ARM)
+#set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_C_COMPILER avr-gcc)
 
 add_executable(tinyg.elf

--- a/firmware/tinyg/CMakeLists.txt
+++ b/firmware/tinyg/CMakeLists.txt
@@ -74,6 +74,6 @@ target_link_options(tinyg.elf PRIVATE -mmcu=atxmega192a3)
 add_custom_command(
 	TARGET tinyg.elf
 	POST_BUILD
-	COMMAND ${CMAKE_OBJCOPY}
+	COMMAND avr-objcopy
 	ARGS -O ihex $<TARGET_FILE:tinyg.elf> ${PROJECT_BINARY_DIR}/tinyg.hex
 )

--- a/firmware/tinyg/CMakeLists.txt
+++ b/firmware/tinyg/CMakeLists.txt
@@ -49,5 +49,25 @@ add_executable(tinyg.elf
     xmega/xmega_rtc.c
 )
 
-target_compile_options(tinyg.elf PRIVATE -mmcu=atxmega192a3 -Os)
-target_link_options(tinyg.elf PRIVATE -mmcu=atxmega192a3 -Os)
+target_compile_definitions(tinyg.elf PRIVATE F_CPU=32000000UL)
+target_compile_options(tinyg.elf PRIVATE
+    -mmcu=atxmega192a3
+    -O2 -g2 -Wall
+    --param=min-pagesize=0
+    -funsigned-char
+    -funsigned-bitfields
+    -fno-align-functions
+    -fno-align-jumps
+    -fno-align-loops
+    -fno-align-labels
+    -fno-reorder-blocks
+    -fno-reorder-blocks-and-partition
+    -fno-prefetch-loop-arrays
+    -fno-tree-vect-loop-version
+    -ffunction-sections
+    -fdata-sections
+    -fpack-struct
+    -fshort-enums
+)
+target_link_options(tinyg.elf PRIVATE -mmcu=atxmega192a3)
+

--- a/firmware/tinyg/CMakeLists.txt
+++ b/firmware/tinyg/CMakeLists.txt
@@ -49,7 +49,10 @@ add_executable(tinyg.elf
     xmega/xmega_rtc.c
 )
 
-target_compile_definitions(tinyg.elf PRIVATE F_CPU=32000000UL)
+target_compile_definitions(tinyg.elf PRIVATE
+    F_CPU=32000000UL
+    M115_BUILD_SYSTEM_STRING=", X-BUILD_SYSTEM:CMake"
+)
 target_compile_options(tinyg.elf PRIVATE
     -mmcu=atxmega192a3
     -O2 -g2 -Wall

--- a/firmware/tinyg/CMakeLists.txt
+++ b/firmware/tinyg/CMakeLists.txt
@@ -53,7 +53,6 @@ target_compile_definitions(tinyg.elf PRIVATE F_CPU=32000000UL)
 target_compile_options(tinyg.elf PRIVATE
     -mmcu=atxmega192a3
     -O2 -g2 -Wall
-    --param=min-pagesize=0
     -funsigned-char
     -funsigned-bitfields
     -fno-align-functions
@@ -69,6 +68,14 @@ target_compile_options(tinyg.elf PRIVATE
     -fpack-struct
     -fshort-enums
 )
+
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER 12.0)
+    message(STATUS "Addding workaround for avr-gcc 12 bug")
+    target_compile_options(tinyg.elf PRIVATE
+        --param=min-pagesize=0
+    )
+endif()
+
 target_link_options(tinyg.elf PRIVATE -mmcu=atxmega192a3)
 
 add_custom_command(

--- a/firmware/tinyg/CMakeLists.txt
+++ b/firmware/tinyg/CMakeLists.txt
@@ -71,3 +71,9 @@ target_compile_options(tinyg.elf PRIVATE
 )
 target_link_options(tinyg.elf PRIVATE -mmcu=atxmega192a3)
 
+add_custom_command(
+	TARGET tinyg.elf
+	POST_BUILD
+	COMMAND ${CMAKE_OBJCOPY}
+	ARGS -O ihex $<TARGET_FILE:tinyg.elf> ${PROJECT_BINARY_DIR}/tinyg.hex
+)

--- a/firmware/tinyg/CMakeLists.txt
+++ b/firmware/tinyg/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.10)
+project(tinyg VERSION 0.1.0)
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_C_COMPILER avr-gcc)
+
+add_executable(tinyg.elf
+    canonical_machine.c
+    config.c
+    config_app.c
+    controller.c
+    cycle_homing.c
+    cycle_jogging.c
+    cycle_probing.c
+    encoder.c
+    gcode_parser.c
+    gpio.c
+    hardware.c
+    help.c
+    json_parser.c
+    kinematics.c
+    main.c
+    network.c
+    persistence.c
+    planner.c
+    plan_arc.c
+    plan_exec.c
+    plan_line.c
+    plan_zoid.c
+    pwm.c
+    report.c
+    spindle.c
+    stepper.c
+    switch.c
+    test.c
+    text_parser.c
+    util.c
+    xio.c
+    xio/xio_file.c
+    xio/xio_pgm.c
+    xio/xio_rs485.c
+    xio/xio_spi.c
+    xio/xio_usart.c
+    xio/xio_usb.c
+    xmega/xmega_adc.c
+    xmega/xmega_eeprom.c
+    xmega/xmega_init.c
+    xmega/xmega_interrupts.c
+    xmega/xmega_rtc.c
+)
+
+target_compile_options(tinyg.elf PRIVATE -mmcu=atxmega192a3 -Os)
+target_link_options(tinyg.elf PRIVATE -mmcu=atxmega192a3 -Os)

--- a/firmware/tinyg/canonical_machine.c
+++ b/firmware/tinyg/canonical_machine.c
@@ -850,7 +850,7 @@ stat_t cm_get_adc()
 stat_t cm_get_firmware()
 {
 	// M115: Get Firmware Version and Capabilities, see https://www.reprap.org/wiki/G-code#M115:_Get_Firmware_Version_and_Capabilities.
-	static const char m115_response[] PROGMEM = "FIRMWARE_NAME:TinyG, FIRMWARE_URL:https%%3A//github.com/synthetos/TinyG, FIRMWARE_VERSION:%0.2f, FIRMWARE_BUILD:%0.2f, HARDWARE_PLATFORM:%0.2f, HARDWARE_VERSION:%0.2f\n";
+	static const char m115_response[] PROGMEM = "FIRMWARE_NAME:TinyG, FIRMWARE_URL:https%%3A//github.com/synthetos/TinyG, FIRMWARE_VERSION:%0.2f, FIRMWARE_BUILD:%0.2f, HARDWARE_PLATFORM:%0.2f, HARDWARE_VERSION:%0.2f, FEATURE_TAGS:OPENPNP/CMAKE\n";
 	fprintf_P(stderr, m115_response, cs.fw_version, cs.fw_build, cs.hw_platform, cs.hw_version);
 	return (STAT_OK);
 }

--- a/firmware/tinyg/canonical_machine.c
+++ b/firmware/tinyg/canonical_machine.c
@@ -847,10 +847,14 @@ stat_t cm_get_adc()
 	return (STAT_OK);
 }
 
+#ifndef M115_BUILD_SYSTEM_STRING
+#define M115_BUILD_SYSTEM_STRING ""
+#endif
+
 stat_t cm_get_firmware()
 {
 	// M115: Get Firmware Version and Capabilities, see https://www.reprap.org/wiki/G-code#M115:_Get_Firmware_Version_and_Capabilities.
-	static const char m115_response[] PROGMEM = "FIRMWARE_NAME:TinyG, FIRMWARE_URL:https%%3A//github.com/synthetos/TinyG, FIRMWARE_VERSION:%0.2f, FIRMWARE_BUILD:%0.2f, HARDWARE_PLATFORM:%0.2f, HARDWARE_VERSION:%0.2f, MACHINE_TYPE:OpenPnP, X-BUILD_SYSTEM:CMake\n";
+	static const char m115_response[] PROGMEM = "FIRMWARE_NAME:TinyG, FIRMWARE_URL:https%%3A//github.com/synthetos/TinyG, FIRMWARE_VERSION:%0.2f, FIRMWARE_BUILD:%0.2f, HARDWARE_PLATFORM:%0.2f, HARDWARE_VERSION:%0.2f, MACHINE_TYPE:OpenPnP" M115_BUILD_SYSTEM_STRING "\n";
 	fprintf_P(stderr, m115_response, cs.fw_version, cs.fw_build, cs.hw_platform, cs.hw_version);
 	return (STAT_OK);
 }

--- a/firmware/tinyg/canonical_machine.c
+++ b/firmware/tinyg/canonical_machine.c
@@ -850,7 +850,7 @@ stat_t cm_get_adc()
 stat_t cm_get_firmware()
 {
 	// M115: Get Firmware Version and Capabilities, see https://www.reprap.org/wiki/G-code#M115:_Get_Firmware_Version_and_Capabilities.
-	static const char m115_response[] PROGMEM = "FIRMWARE_NAME:TinyG, FIRMWARE_URL:https%%3A//github.com/synthetos/TinyG, FIRMWARE_VERSION:%0.2f, FIRMWARE_BUILD:%0.2f, HARDWARE_PLATFORM:%0.2f, HARDWARE_VERSION:%0.2f, FEATURE_TAGS:OPENPNP/CMAKE\n";
+	static const char m115_response[] PROGMEM = "FIRMWARE_NAME:TinyG, FIRMWARE_URL:https%%3A//github.com/synthetos/TinyG, FIRMWARE_VERSION:%0.2f, FIRMWARE_BUILD:%0.2f, HARDWARE_PLATFORM:%0.2f, HARDWARE_VERSION:%0.2f, MACHINE_TYPE:OpenPnP, X-BUILD_SYSTEM:CMake\n";
 	fprintf_P(stderr, m115_response, cs.fw_version, cs.fw_build, cs.hw_platform, cs.hw_version);
 	return (STAT_OK);
 }

--- a/firmware/tinyg/controller.c
+++ b/firmware/tinyg/controller.c
@@ -276,8 +276,9 @@ static stat_t _command_dispatch()
 		}
 		default: {										// anything else must be Gcode
 			if (cfg.comm_mode == JSON_MODE) {			// run it as JSON...
-				strncpy(cs.out_buf, cs.bufp, INPUT_BUFFER_LEN -8);					// use out_buf as temp
-				sprintf((char *)cs.bufp,"{\"gc\":\"%s\"}\n", (char *)cs.out_buf);	// '-8' is used for JSON chars
+				strncpy(cs.out_buf, cs.bufp, INPUT_BUFFER_LEN -10);					// use out_buf as temp
+				cs.out_buf[INPUT_BUFFER_LEN-10] = '\0';
+				snprintf(cs.bufp,INPUT_BUFFER_LEN,"{\"gc\":\"%.244s\"}\n", cs.out_buf);	// 10 chars used for JSON shell
 				json_parser(cs.bufp);
 			} else {									//...or run it as text
 				text_response(gc_gcode_parser(cs.bufp), cs.saved_buf);

--- a/firmware/tinyg/encoder.c
+++ b/firmware/tinyg/encoder.c
@@ -47,6 +47,9 @@ enEncoders_t en;
 
 void encoder_init()
 {
+#ifdef AS_5600_ENCODER
+	as5600_init();
+#endif
 	memset(&en, 0, sizeof(en));		// clear all values, pointers and status
 	encoder_init_assertions();
 }

--- a/firmware/tinyg/encoder.c
+++ b/firmware/tinyg/encoder.c
@@ -28,6 +28,10 @@
 #include "tinyg.h"
 #include "config.h"
 #include "encoder.h"
+#include "xmega/xmega_twi.h"
+
+// Hardware encoder support
+#include "encoder_as5600.h"
 
 #ifdef __cplusplus
 extern "C"{
@@ -41,15 +45,24 @@ enEncoders_t en;
  **** CODE **************************************************************************
  ************************************************************************************/
 
+// i2c_init and i2c_deinit are already handled elsewhere
+// so we need to do nothing on the as5600 handler for those
+// function pointers.
+void nop() {}
+
 /*
  * encoder_init() - initialize encoders
  */
 
 void encoder_init()
 {
+as5600_handle_t handler = { &nop, &nop, &read_TWI, &send_TWI, 0, printf, 1 };
+// Real hardware sensor(s)
 #ifdef AS_5600_ENCODER
-	as5600_init();
+	as5600_init(&handler);
 #endif
+
+// Fake one
 	memset(&en, 0, sizeof(en));		// clear all values, pointers and status
 	encoder_init_assertions();
 }

--- a/firmware/tinyg/encoder_as5600.c
+++ b/firmware/tinyg/encoder_as5600.c
@@ -1,0 +1,1421 @@
+// https://github.com/libdriver/as5600
+
+/**
+ * Copyright (c) 2015 - present LibDriver All rights reserved
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * @file      driver_as5600.c
+ * @brief     driver as5600 source file
+ * @version   1.0.0
+ * @author    Shifeng Li
+ * @date      2022-09-30
+ *
+ * <h3>history</h3>
+ * <table>
+ * <tr><th>Date        <th>Version  <th>Author      <th>Description
+ * <tr><td>2022/09/30  <td>1.0      <td>Shifeng Li  <td>first upload
+ * </table>
+ */
+
+#define NULL 0
+#include "encoder_as5600.h"
+
+/**
+ * @brief chip information definition
+ */
+#define CHIP_NAME                 "AMS AS5600"        /**< chip name */
+#define MANUFACTURER_NAME         "AMS"               /**< manufacturer name */
+#define SUPPLY_VOLTAGE_MIN        4.5f                /**< chip min supply voltage */
+#define SUPPLY_VOLTAGE_MAX        5.5f                /**< chip max supply voltage */
+#define MAX_CURRENT               100.0f              /**< chip max current */
+#define TEMPERATURE_MIN           -40.0f              /**< chip min operating temperature */
+#define TEMPERATURE_MAX           125.0f              /**< chip max operating temperature */
+#define DRIVER_VERSION            1000                /**< driver version */
+
+/**
+ * @brief chip address definition
+ */
+#define AS5600_ADDRESS            0x6C        /**< iic device address */
+
+/**
+ * @brief chip register definition
+ */
+#define AS5600_REG_ZMCO               0x00        /**< written times register */
+#define AS5600_REG_ZPOS_H             0x01        /**< start position register high */
+#define AS5600_REG_ZPOS_L             0x02        /**< start position register low */
+#define AS5600_REG_MPOS_H             0x03        /**< stop position register high */
+#define AS5600_REG_MPOS_L             0x04        /**< stop position register low */
+#define AS5600_REG_MANG_H             0x05        /**< maximum angle register high */
+#define AS5600_REG_MANG_L             0x06        /**< maximum angle register low */
+#define AS5600_REG_CONF_H             0x07        /**< conf register high */
+#define AS5600_REG_CONF_L             0x08        /**< conf register low */
+#define AS5600_REG_RAW_ANGLE_H        0x0C        /**< raw angle register high */
+#define AS5600_REG_RAW_ANGLE_L        0x0D        /**< raw angle register low */
+#define AS5600_REG_ANGLE_H            0x0E        /**< angle register high */
+#define AS5600_REG_ANGLE_L            0x0F        /**< angle register low */
+#define AS5600_REG_STATUS             0x0B        /**< status register */
+#define AS5600_REG_AGC                0x1A        /**< automatic gain control register */
+#define AS5600_REG_MAGNITUDE_H        0x1B        /**< magnitude register high */
+#define AS5600_REG_MAGNITUDE_L        0x1C        /**< magnitude register low */
+#define AS5600_REG_BURN               0xFF        /**< burn register */
+
+/**
+ * @brief      read bytes
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[in]  reg is the iic register address
+ * @param[out] *data points to a data buffer
+ * @param[in]  len is the data length
+ * @return     status code
+ *             - 0 success
+ *             - 1 read failed
+ * @note       none
+ */
+static uint8_t a_as5600_iic_read(as5600_handle_t *handle, uint8_t reg, uint8_t *data, uint16_t len)
+{
+    if (handle->iic_read(AS5600_ADDRESS, reg, data, len) != 0)        /* read the register */
+    {
+        return 1;                                                     /* return error */
+    }
+    else
+    {
+        return 0;                                                     /* success return 0 */
+    }
+}
+
+/**
+ * @brief     write bytes
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] reg is the iic register address
+ * @param[in] *data points to a data buffer
+ * @param[in] len is the data length
+ * @return    status code
+ *            - 0 success
+ *            - 1 write failed
+ * @note      none
+ */
+static uint8_t a_as5600_iic_write(as5600_handle_t *handle, uint8_t reg, uint8_t *data, uint16_t len)
+{
+    if (handle->iic_write(AS5600_ADDRESS, reg, data, len) != 0)       /* write the register */
+    {
+        return 1;                                                     /* return error */
+    }
+    else
+    {
+        return 0;                                                     /* success return 0 */
+    }
+}
+
+/**
+ * @brief     initialize the chip
+ * @param[in] *handle points to an as5600 handle structure
+ * @return    status code
+ *            - 0 success
+ *            - 1 iic initialization failed
+ *            - 2 handle is NULL
+ *            - 3 linked functions is NULL
+ * @note      none
+ */
+uint8_t as5600_init(as5600_handle_t *handle)
+{
+    if (handle == NULL)                                              /* check handle */
+    {
+        return 2;                                                    /* return error */
+    }
+    if (handle->debug_print == NULL)                                 /* check debug_print */
+    {
+        return 3;                                                    /* return error */
+    }
+    if (handle->iic_init == NULL)                                    /* check iic_init */
+    {
+        handle->debug_print("as5600: iic_init is null.\n");          /* iic_init is null */
+
+        return 3;                                                    /* return error */
+    }
+    if (handle->iic_deinit == NULL)                                  /* check iic_init */
+    {
+        handle->debug_print("as5600: iic_deinit is null.\n");        /* iic_deinit is null */
+
+        return 3;                                                    /* return error */
+    }
+    if (handle->iic_read == NULL)                                    /* check iic_read */
+    {
+        handle->debug_print("as5600: iic_read is null.\n");          /* iic_read is null */
+
+        return 3;                                                    /* return error */
+    }
+    if (handle->iic_write == NULL)                                   /* check iic_write */
+    {
+        handle->debug_print("as5600: iic_write is null.\n");         /* iic_write is null */
+
+        return 3;                                                    /* return error */
+    }
+    if (handle->delay_ms == NULL)                                    /* check delay_ms */
+    {
+        handle->debug_print("as5600: delay_ms is null.\n");          /* delay_ms is null */
+
+        return 3;                                                    /* return error */
+    }
+
+    if (handle->iic_init() != 0)                                     /* iic init */
+    {
+        handle->debug_print("as5600: iic init failed.\n");           /* iic init failed */
+
+        return 1;                                                    /* return error */
+    }
+    handle->inited = 1;                                              /* flag finish initialization */
+
+    return 0;                                                        /* success return 0 */
+}
+
+/**
+ * @brief     close the chip
+ * @param[in] *handle points to an as5600 handle structure
+ * @return    status code
+ *            - 0 success
+ *            - 1 iic deinit failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_deinit(as5600_handle_t *handle)
+{
+    if (handle == NULL)                                             /* check handle */
+    {
+        return 2;                                                   /* return error */
+    }
+    if (handle->inited != 1)                                        /* check handle initialization */
+    {
+        return 3;                                                   /* return error */
+    }
+
+    if (handle->iic_deinit() != 0)                                  /* iic deinit */
+    {
+        handle->debug_print("as5600: iic deinit failed.\n");        /* iic deinit failed */
+
+        return 1;                                                   /* return error */
+    }
+    handle->inited = 0;                                             /* flag close */
+
+    return 0;                                                       /* success return 0 */
+}
+
+/**
+ * @brief      read the magnetic angle
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *angle_raw points to a raw angle buffer
+ * @param[out] *deg points to a converted angle buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 read failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_read(as5600_handle_t *handle, uint16_t *angle_raw, float *deg)
+{
+    uint8_t buf[2];
+
+    if (handle == NULL)                                                        /* check handle */
+    {
+        return 2;                                                              /* return error */
+    }
+    if (handle->inited != 1)                                                   /* check handle initialization */
+    {
+        return 3;                                                              /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_RAW_ANGLE_H, buf, 2) != 0)        /* read conf */
+    {
+        handle->debug_print("as5600: get raw angle failed.\n");                /* get raw angle failed */
+
+        return 1;                                                              /* return error */
+    }
+    else
+    {
+        *angle_raw = (uint16_t)(((buf[0] >> 0) & 0xF) << 8) | buf[1];          /* set the raw angle */
+        *deg = (float)(*angle_raw ) * (360.0f / 4096.0f);                      /* convert the raw data to the real data */
+
+        return 0;                                                              /* success return 0 */
+    }
+}
+
+/**
+ * @brief      convert the angle to the register raw data
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[in]  deg is the angle
+ * @param[out] *reg points to a register raw buffer
+ * @return     status code
+ *             - 0 success
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_angle_convert_to_register(as5600_handle_t *handle, float deg, uint16_t *reg)
+{
+    if (handle == NULL)                                  /* check handle */
+    {
+        return 2;                                        /* return error */
+    }
+    if (handle->inited != 1)                             /* check handle initialization */
+    {
+        return 3;                                        /* return error */
+    }
+
+    *reg = (uint16_t)(deg / (360.0f / 4096.0f));         /* convert real data to register data */
+
+    return 0;                                            /* success return 0 */
+}
+
+/**
+ * @brief      convert the register raw data to the angle
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[in]  reg is the register raw data
+ * @param[out] *deg points to an angle buffer
+ * @return     status code
+ *             - 0 success
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_angle_convert_to_data(as5600_handle_t *handle, uint16_t reg, float *deg)
+{
+    if (handle == NULL)                              /* check handle */
+    {
+        return 2;                                    /* return error */
+    }
+    if (handle->inited != 1)                         /* check handle initialization */
+    {
+        return 3;                                    /* return error */
+    }
+
+    *deg = (float)(reg) * (360.0f / 4096.0f);        /* convert raw data to real data */
+
+    return 0;                                        /* success return 0 */
+}
+
+/**
+ * @brief     set the start position
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] pos is the start position
+ * @return    status code
+ *            - 0 success
+ *            - 1 set start position failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ *            - 4 pos is over 0xFFF
+ * @note      none
+ */
+uint8_t as5600_set_start_position(as5600_handle_t *handle, uint16_t pos)
+{
+    uint8_t buf[2];
+
+    if (handle == NULL)                                                     /* check handle */
+    {
+        return 2;                                                           /* return error */
+    }
+    if (handle->inited != 1)                                                /* check handle initialization */
+    {
+        return 3;                                                           /* return error */
+    }
+    if (pos > 0xFFF)                                                        /* check the pos */
+    {
+        handle->debug_print("as5600: pos is over 0xFFF.\n");                /* pos is over 0xFFF */
+
+        return 4;                                                           /* return error */
+    }
+
+    buf[0] = (pos >> 8) & 0x0F;                                             /* set high part */
+    buf[1] = (pos >> 0) & 0xFF;                                             /* set low part */
+    if (a_as5600_iic_write(handle, AS5600_REG_ZPOS_H, buf, 2) != 0)         /* write conf */
+    {
+        handle->debug_print("as5600: set start position failed.\n");        /* set start position failed */
+
+        return 1;                                                           /* return error */
+    }
+    else
+    {
+        return 0;                                                           /* success return 0 */
+    }
+}
+
+/**
+ * @brief      get the start position
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *pos points to a start position buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get start position failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_start_position(as5600_handle_t *handle, uint16_t *pos)
+{
+    uint8_t buf[2];
+
+    if (handle == NULL)                                                     /* check handle */
+    {
+        return 2;                                                           /* return error */
+    }
+    if (handle->inited != 1)                                                /* check handle initialization */
+    {
+        return 3;                                                           /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_ZPOS_H, buf, 2) != 0)          /* read conf */
+    {
+        handle->debug_print("as5600: get start position failed.\n");        /* get start position failed */
+
+        return 1;                                                           /* return error */
+    }
+    else
+    {
+        *pos = (uint16_t)(((buf[0] >> 0) & 0xF) << 8) | buf[1];             /* set the position */
+
+        return 0;                                                           /* success return 0 */
+    }
+}
+
+/**
+ * @brief     set the stop position
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] pos is the stop position
+ * @return    status code
+ *            - 0 success
+ *            - 1 set stop position failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ *            - 4 pos is over 0xFFF
+ * @note      none
+ */
+uint8_t as5600_set_stop_position(as5600_handle_t *handle, uint16_t pos)
+{
+    uint8_t buf[2];
+
+    if (handle == NULL)                                                     /* check handle */
+    {
+        return 2;                                                           /* return error */
+    }
+    if (handle->inited != 1)                                                /* check handle initialization */
+    {
+        return 3;                                                           /* return error */
+    }
+    if (pos > 0xFFF)                                                        /* check the pos */
+    {
+        handle->debug_print("as5600: pos is over 0xFFF.\n");                /* pos is over 0xFFF */
+
+        return 4;                                                           /* return error */
+    }
+
+    buf[0] = (pos >> 8) & 0x0F;                                             /* set high part */
+    buf[1] = (pos >> 0) & 0xFF;                                             /* set low part */
+    if (a_as5600_iic_write(handle, AS5600_REG_MPOS_H, buf, 2) != 0)         /* write conf */
+    {
+        handle->debug_print("as5600: set stop position failed.\n");         /* set stop position failed */
+
+        return 1;                                                           /* return error */
+    }
+    else
+    {
+        return 0;                                                           /* success return 0 */
+    }
+}
+
+/**
+ * @brief      get the stop position
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *pos points to a stop position buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get stop position failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_stop_position(as5600_handle_t *handle, uint16_t *pos)
+{
+    uint8_t buf[2];
+
+    if (handle == NULL)                                                     /* check handle */
+    {
+        return 2;                                                           /* return error */
+    }
+    if (handle->inited != 1)                                                /* check handle initialization */
+    {
+        return 3;                                                           /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_MPOS_H, buf, 2) != 0)          /* read conf */
+    {
+        handle->debug_print("as5600: get stop position failed.\n");         /* get stop position failed */
+
+        return 1;                                                           /* return error */
+    }
+    else
+    {
+        *pos = (uint16_t)(((buf[0] >> 0) & 0xF) << 8) | buf[1];             /* set the position */
+
+        return 0;                                                           /* success return 0 */
+    }
+}
+
+/**
+ * @brief     set the max angle
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] ang is the max angle
+ * @return    status code
+ *            - 0 success
+ *            - 1 set max angle failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ *            - 4 ang is over 0xFFF
+ * @note      none
+ */
+uint8_t as5600_set_max_angle(as5600_handle_t *handle, uint16_t ang)
+{
+    uint8_t buf[2];
+
+    if (handle == NULL)                                                     /* check handle */
+    {
+        return 2;                                                           /* return error */
+    }
+    if (handle->inited != 1)                                                /* check handle initialization */
+    {
+        return 3;                                                           /* return error */
+    }
+    if (ang > 0xFFF)                                                        /* check the ang */
+    {
+        handle->debug_print("as5600: ang is over 0xFFF.\n");                /* ang is over 0xFFF */
+
+        return 4;                                                           /* return error */
+    }
+
+    buf[0] = (ang >> 8) & 0x0F;                                             /* set high part */
+    buf[1] = (ang >> 0) & 0xFF;                                             /* set low part */
+    if (a_as5600_iic_write(handle, AS5600_REG_MANG_H, buf, 2) != 0)         /* write conf */
+    {
+        handle->debug_print("as5600: set max angle failed.\n");             /* set max angle failed */
+
+        return 1;                                                           /* return error */
+    }
+    else
+    {
+        return 0;                                                           /* success return 0 */
+    }
+}
+
+/**
+ * @brief      get the max angle
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *ang points to a max angle buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get max angle failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_max_angle(as5600_handle_t *handle, uint16_t *ang)
+{
+    uint8_t buf[2];
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_MANG_H, buf, 2) != 0)        /* read conf */
+    {
+        handle->debug_print("as5600: get max angle failed.\n");           /* get max angle failed */
+
+        return 1;                                                         /* return error */
+    }
+    else
+    {
+        *ang = (uint16_t)(((buf[0] >> 0) & 0xF) << 8) | buf[1];           /* set the position */
+
+        return 0;                                                         /* success return 0 */
+    }
+}
+
+/**
+ * @brief     enable or disable the watch dog
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] enable is a bool value
+ * @return    status code
+ *            - 0 success
+ *            - 1 set watchdog failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_watch_dog(as5600_handle_t *handle, as5600_bool_t enable)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_H, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    prev &= ~(1 << 5);                                                    /* clear the settings */
+    prev |= enable << 5;                                                  /* set the bool */
+    if (a_as5600_iic_write(handle, AS5600_REG_CONF_H, &prev, 1) != 0)     /* write conf */
+    {
+        handle->debug_print("as5600: set conf failed.\n");                /* set conf failed */
+
+        return 1;                                                         /* return error */
+    }
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief      get the watch dog status
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *enable points to a bool value buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get watchdog failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_watch_dog(as5600_handle_t *handle, as5600_bool_t *enable)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_H, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    *enable = (as5600_bool_t)((prev >> 5) & 0x1);                         /* get the bool */
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief     set the fast filter threshold
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] threshold is the fast filter threshold
+ * @return    status code
+ *            - 0 success
+ *            - 1 set fast filter threshold failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_fast_filter_threshold(as5600_handle_t *handle, as5600_fast_filter_threshold_t threshold)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_H, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    prev &= ~(7 << 2);                                                    /* clear the settings */
+    prev |= threshold << 2;                                               /* set the threshold */
+    if (a_as5600_iic_write(handle, AS5600_REG_CONF_H, &prev, 1) != 0)     /* write conf */
+    {
+        handle->debug_print("as5600: set conf failed.\n");                /* set conf failed */
+
+        return 1;                                                         /* return error */
+    }
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief      get the fast filter threshold
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *threshold points to a fast filter threshold buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get fast filter threshold failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_fast_filter_threshold(as5600_handle_t *handle, as5600_fast_filter_threshold_t *threshold)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_H, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    *threshold = (as5600_fast_filter_threshold_t)((prev >> 2) & 0x7);     /* set the threshold */
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief     set the slow filter
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] filter is the slow filter
+ * @return    status code
+ *            - 0 success
+ *            - 1 set slow filter failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_slow_filter(as5600_handle_t *handle, as5600_slow_filter_t filter)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_H, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    prev &= ~(3 << 0);                                                    /* clear the settings */
+    prev |= filter << 0;                                                  /* set the filter */
+    if (a_as5600_iic_write(handle, AS5600_REG_CONF_H, &prev, 1) != 0)     /* write conf */
+    {
+        handle->debug_print("as5600: set conf failed.\n");                /* set conf failed */
+
+        return 1;                                                         /* return error */
+    }
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief      get the slow filter
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *filter points to a slow filter buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get slow filter failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_slow_filter(as5600_handle_t *handle, as5600_slow_filter_t *filter)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_H, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    *filter = (as5600_slow_filter_t)(prev & 0x3);                         /* get the filter */
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief     set the pwm frequency
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] freq is the pwm frequency
+ * @return    status code
+ *            - 0 success
+ *            - 1 set pwm frequency failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_pwm_frequency(as5600_handle_t *handle, as5600_pwm_frequency_t freq)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_L, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    prev &= ~(3 << 6);                                                    /* clear the settings */
+    prev |= freq << 6;                                                    /* set the freq */
+    if (a_as5600_iic_write(handle, AS5600_REG_CONF_L, &prev, 1) != 0)     /* write conf */
+    {
+        handle->debug_print("as5600: set conf failed.\n");                /* set conf failed */
+
+        return 1;                                                         /* return error */
+    }
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief      get the pwm frequency
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *freq points to a pwm frequency buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get pwm frequency failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_pwm_frequency(as5600_handle_t *handle, as5600_pwm_frequency_t *freq)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_L, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    *freq = (as5600_pwm_frequency_t)((prev >> 6) & 0x3);                  /* set the frequency */
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief     set the output stage
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] stage is the output stage
+ * @return    status code
+ *            - 0 success
+ *            - 1 set output stage failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_output_stage(as5600_handle_t *handle, as5600_output_stage_t stage)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_L, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    prev &= ~(3 << 4);                                                    /* clear the settings */
+    prev |= stage << 4;                                                   /* set the stage */
+    if (a_as5600_iic_write(handle, AS5600_REG_CONF_L, &prev, 1) != 0)     /* write conf */
+    {
+        handle->debug_print("as5600: set conf failed.\n");                /* set conf failed */
+
+        return 1;                                                         /* return error */
+    }
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief      get the output stage
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *stage points to an output stage buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get output stage failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_output_stage(as5600_handle_t *handle, as5600_output_stage_t *stage)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_L, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    *stage = (as5600_output_stage_t)((prev >> 4) & 0x3);                  /* get the output stage */
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief     set the hysteresis
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] hysteresis is the set hysteresis
+ * @return    status code
+ *            - 0 success
+ *            - 1 set hysteresis failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_hysteresis(as5600_handle_t *handle, as5600_hysteresis_t hysteresis)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_L, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    prev &= ~(3 << 2);                                                    /* clear the settings */
+    prev |= hysteresis << 2;                                              /* set the hysteresis */
+    if (a_as5600_iic_write(handle, AS5600_REG_CONF_L, &prev, 1) != 0)     /* write conf */
+    {
+        handle->debug_print("as5600: set conf failed.\n");                /* set conf failed */
+
+        return 1;                                                         /* return error */
+    }
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief      get the hysteresis
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *hysteresis points to a hysteresis buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get hysteresis failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_hysteresis(as5600_handle_t *handle, as5600_hysteresis_t *hysteresis)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_L, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    *hysteresis = (as5600_hysteresis_t)((prev >> 2) & 0x3);               /* get the hysteresis */
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief     set the power mode
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] mode is the power mode
+ * @return    status code
+ *            - 0 success
+ *            - 1 set power mode failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_power_mode(as5600_handle_t *handle, as5600_power_mode_t mode)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_L, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    prev &= ~(3 << 0);                                                    /* clear the settings */
+    prev |= mode << 0;                                                    /* set the power mode */
+    if (a_as5600_iic_write(handle, AS5600_REG_CONF_L, &prev, 1) != 0)     /* write conf */
+    {
+        handle->debug_print("as5600: set conf failed.\n");                /* set conf failed */
+
+        return 1;                                                         /* return error */
+    }
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief      get the power mode
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *mode points to a power mode buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get power mode failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_power_mode(as5600_handle_t *handle, as5600_power_mode_t *mode)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                   /* check handle */
+    {
+        return 2;                                                         /* return error */
+    }
+    if (handle->inited != 1)                                              /* check handle initialization */
+    {
+        return 3;                                                         /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_CONF_L, &prev, 1) != 0)      /* read conf */
+    {
+        handle->debug_print("as5600: get conf failed.\n");                /* get conf failed */
+
+        return 1;                                                         /* return error */
+    }
+    *mode = (as5600_power_mode_t)((prev >> 0) & 0x3);                     /* get the power mode */
+
+    return 0;                                                             /* success return 0 */
+}
+
+/**
+ * @brief      get the raw angle
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *ang points to an ang buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get raw angle failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_raw_angle(as5600_handle_t *handle, uint16_t *ang)
+{
+    uint8_t buf[2];
+
+    if (handle == NULL)                                                        /* check handle */
+    {
+        return 2;                                                              /* return error */
+    }
+    if (handle->inited != 1)                                                   /* check handle initialization */
+    {
+        return 3;                                                              /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_RAW_ANGLE_H, buf, 2) != 0)        /* read conf */
+    {
+        handle->debug_print("as5600: get raw angle failed.\n");                /* get raw angle failed */
+
+        return 1;                                                              /* return error */
+    }
+    else
+    {
+        *ang = (uint16_t)(((buf[0] >> 0) & 0xF) << 8) | buf[1];                /* set the angle */
+
+        return 0;                                                              /* success return 0 */
+    }
+}
+
+/**
+ * @brief      get the angle
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *ang points to an ang buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get angle failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_angle(as5600_handle_t *handle, uint16_t *ang)
+{
+    uint8_t buf[2];
+
+    if (handle == NULL)                                                    /* check handle */
+    {
+        return 2;                                                          /* return error */
+    }
+    if (handle->inited != 1)                                               /* check handle initialization */
+    {
+        return 3;                                                          /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_ANGLE_H, buf, 2) != 0)        /* read conf */
+    {
+        handle->debug_print("as5600: get angle failed.\n");                /* get angle failed */
+
+        return 1;                                                          /* return error */
+    }
+    else
+    {
+        *ang = (uint16_t)(((buf[0] >> 0) & 0xF) << 8) | buf[1];            /* set the angle */
+
+        return 0;                                                          /* success return 0 */
+    }
+}
+
+/**
+ * @brief      get the status
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *status points to a status buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get status failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_status(as5600_handle_t *handle, uint8_t *status)
+{
+    if (handle == NULL)                                                      /* check handle */
+    {
+        return 2;                                                            /* return error */
+    }
+    if (handle->inited != 1)                                                 /* check handle initialization */
+    {
+        return 3;                                                            /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_STATUS, status, 1) != 0)        /* read conf */
+    {
+        handle->debug_print("as5600: get status failed.\n");                 /* get status failed */
+
+        return 1;                                                            /* return error */
+    }
+    else
+    {
+        return 0;                                                            /* success return 0 */
+    }
+}
+
+/**
+ * @brief      get the automatic gain control
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *agc points to an agc buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get agc failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_agc(as5600_handle_t *handle, uint8_t *agc)
+{
+    if (handle == NULL)                                                /* check handle */
+    {
+        return 2;                                                      /* return error */
+    }
+    if (handle->inited != 1)                                           /* check handle initialization */
+    {
+        return 3;                                                      /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_AGC, agc, 1) != 0)        /* read conf */
+    {
+        handle->debug_print("as5600: get agc failed.\n");              /* get agc failed */
+
+        return 1;                                                      /* return error */
+    }
+    else
+    {
+        return 0;                                                      /* success return 0 */
+    }
+}
+
+/**
+ * @brief      get the magnitude
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *magnitude points to a magnitude buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get magnitude failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_magnitude(as5600_handle_t *handle, uint16_t *magnitude)
+{
+    uint8_t buf[2];
+
+    if (handle == NULL)                                                        /* check handle */
+    {
+        return 2;                                                              /* return error */
+    }
+    if (handle->inited != 1)                                                   /* check handle initialization */
+    {
+        return 3;                                                              /* return error */
+    }
+
+    if (a_as5600_iic_read(handle, AS5600_REG_MAGNITUDE_H, buf, 2) != 0)        /* read conf */
+    {
+        handle->debug_print("as5600: get magnitude failed.\n");                /* get magnitude failed */
+
+        return 1;                                                              /* return error */
+    }
+    else
+    {
+        *magnitude = (uint16_t)(((buf[0] >> 0) & 0xF) << 8) | buf[1];          /* set the angle */
+
+        return 0;                                                              /* success return 0 */
+    }
+}
+
+/**
+ * @brief     set the burn
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] burn is the set command
+ * @return    status code
+ *            - 0 success
+ *            - 1 set burn failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_burn(as5600_handle_t *handle, as5600_burn_t burn)
+{
+    uint8_t prev;
+
+    if (handle == NULL)                                                    /* check handle */
+    {
+        return 2;                                                          /* return error */
+    }
+    if (handle->inited != 1)                                               /* check handle initialization */
+    {
+        return 3;                                                          /* return error */
+    }
+
+    prev = burn;                                                           /* set the burn */
+    if (a_as5600_iic_write(handle, AS5600_REG_BURN, &prev, 1) != 0)        /* write conf */
+    {
+        handle->debug_print("as5600: set burn failed.\n");                 /* set burn failed */
+
+        return 1;                                                          /* return error */
+    }
+
+    return 0;                                                              /* success return 0 */
+}
+
+/**
+ * @brief     set the chip register
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] reg is the iic register address
+ * @param[in] *buf points to a data buffer
+ * @param[in] len is the data buffer length
+ * @return    status code
+ *            - 0 success
+ *            - 1 write failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_reg(as5600_handle_t *handle, uint8_t reg, uint8_t *buf, uint16_t len)
+{
+    uint8_t res;
+
+    if (handle == NULL)                                                 /* check handle */
+    {
+        return 2;                                                       /* return error */
+    }
+    if (handle->inited != 1)                                            /* check handle initialization */
+    {
+        return 3;                                                       /* return error */
+    }
+
+    res = a_as5600_iic_write(handle, reg, buf, len);                    /* write data */
+    if (res != 0)                                                       /* check result */
+    {
+        handle->debug_print("as5600: write register failed.\n");        /* write register failed */
+
+        return 1;                                                       /* return error */
+    }
+
+    return 0;                                                           /* success return 0 */
+}
+
+/**
+ * @brief      get the chip register
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[in]  reg is the iic register address
+ * @param[out] *buf points to a data buffer
+ * @param[in]  len is the data buffer length
+ * @return     status code
+ *             - 0 success
+ *             - 1 read failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_reg(as5600_handle_t *handle, uint8_t reg, uint8_t *buf, uint16_t len)
+{
+    uint8_t res;
+
+    if (handle == NULL)                                                /* check handle */
+    {
+        return 2;                                                      /* return error */
+    }
+    if (handle->inited != 1)                                           /* check handle initialization */
+    {
+        return 3;                                                      /* return error */
+    }
+
+    res = a_as5600_iic_read(handle, reg, buf, len);                    /* read data */
+    if (res != 0)                                                      /* check result */
+    {
+        handle->debug_print("as5600: read register failed.\n");        /* read register failed */
+
+        return 1;                                                      /* return error */
+    }
+
+    return 0;                                                          /* success return 0 */
+}
+
+/**
+ * @brief      get chip's information
+ * @param[out] *info points to an as5600 info structure
+ * @return     status code
+ *             - 0 success
+ *             - 2 handle is NULL
+ * @note       none
+ */
+uint8_t as5600_info(as5600_info_t *info)
+{
+    if (info == NULL)                                               /* check handle */
+    {
+        return 2;                                                   /* return error */
+    }
+
+    memset(info, 0, sizeof(as5600_info_t));                         /* initialize as5600 info structure */
+    strncpy(info->chip_name, CHIP_NAME, 32);                        /* copy chip name */
+    strncpy(info->manufacturer_name, MANUFACTURER_NAME, 32);        /* copy manufacturer name */
+    strncpy(info->interface, "IIC", 8);                             /* copy interface name */
+    info->supply_voltage_min_v = SUPPLY_VOLTAGE_MIN;                /* set minimal supply voltage */
+    info->supply_voltage_max_v = SUPPLY_VOLTAGE_MAX;                /* set maximum supply voltage */
+    info->max_current_ma = MAX_CURRENT;                             /* set maximum current */
+    info->temperature_max = TEMPERATURE_MAX;                        /* set minimal temperature */
+    info->temperature_min = TEMPERATURE_MIN;                        /* set maximum temperature */
+    info->driver_version = DRIVER_VERSION;                          /* set driver version */
+
+    return 0;                                                       /* success return 0 */
+}

--- a/firmware/tinyg/encoder_as5600.h
+++ b/firmware/tinyg/encoder_as5600.h
@@ -1,0 +1,735 @@
+/**
+ * Copyright (c) 2015 - present LibDriver All rights reserved
+ * 
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE. 
+ *
+ * @file      driver_as5600.h
+ * @brief     driver as5600 header file
+ * @version   1.0.0
+ * @author    Shifeng Li
+ * @date      2022-09-30
+ *
+ * <h3>history</h3>
+ * <table>
+ * <tr><th>Date        <th>Version  <th>Author      <th>Description
+ * <tr><td>2022/09/30  <td>1.0      <td>Shifeng Li  <td>first upload
+ * </table>
+ */
+
+#ifndef DRIVER_AS5600_H
+#define DRIVER_AS5600_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+/**
+ * @defgroup as5600_driver as5600 driver function
+ * @brief    as5600 driver modules
+ * @{
+ */
+
+/**
+ * @addtogroup as5600_base_driver
+ * @{
+ */
+
+/**
+ * @brief as5600 bool enumeration definition
+ */
+typedef enum
+{
+    AS5600_BOOL_FALSE = 0x00,        /**< disable */
+    AS5600_BOOL_TRUE  = 0x01,        /**< enable */
+} as5600_bool_t;
+
+/**
+ * @brief as5600 power mode enumeration definition
+ */
+typedef enum
+{
+    AS5600_POWER_MODE_NOM  = 0x00,        /**< normal */
+    AS5600_POWER_MODE_LPM1 = 0x01,        /**< low power 1 */
+    AS5600_POWER_MODE_LPM2 = 0x02,        /**< low power 2 */
+    AS5600_POWER_MODE_LPM3 = 0x03,        /**< low power 3 */
+} as5600_power_mode_t;
+
+/**
+ * @brief as5600 hysteresis enumeration definition
+ */
+typedef enum
+{
+    AS5600_HYSTERESIS_OFF  = 0x00,        /**< off */
+    AS5600_HYSTERESIS_1LSB = 0x01,        /**< 1 lsb */
+    AS5600_HYSTERESIS_2LSB = 0x02,        /**< 2 lsb */
+    AS5600_HYSTERESIS_3LSB = 0x03,        /**< 3 lsb */
+} as5600_hysteresis_t;
+
+/**
+ * @brief as5600 output stage enumeration definition
+ */
+typedef enum
+{
+    AS5600_OUTPUT_STAGE_ANALOG_FULL    = 0x00,        /**< full range from 0% to 100% between gnd and vdd */
+    AS5600_OUTPUT_STAGE_ANALOG_REDUCED = 0x01,        /**< reduced range from 10% to 90% between gnd and vdd */
+    AS5600_OUTPUT_STAGE_PWM            = 0x02,        /**< digital pwm */
+} as5600_output_stage_t;
+
+/**
+ * @brief as5600 pwm frequency enumeration definition
+ */
+typedef enum
+{
+    AS5600_PWM_FREQUENCY_115HZ = 0x00,        /**< 115Hz */
+    AS5600_PWM_FREQUENCY_230HZ = 0x01,        /**< 230Hz */
+    AS5600_PWM_FREQUENCY_460HZ = 0x02,        /**< 460Hz */
+    AS5600_PWM_FREQUENCY_920HZ = 0x03,        /**< 920Hz */
+} as5600_pwm_frequency_t;
+
+/**
+ * @brief as5600 slow filter enumeration definition
+ */
+typedef enum
+{
+    AS5600_SLOW_FILTER_16X = 0x00,        /**< 16x */
+    AS5600_SLOW_FILTER_8X  = 0x01,        /**< 8x */
+    AS5600_SLOW_FILTER_4X  = 0x02,        /**< 4x */
+    AS5600_SLOW_FILTER_2X  = 0x03,        /**< 2x */
+} as5600_slow_filter_t;
+
+/**
+ * @brief as5600 fast filter threshold enumeration definition
+ */
+typedef enum
+{
+    AS5600_FAST_FILTER_THRESHOLD_SLOW_FILTER_ONLY = 0x00,        /**< slow filter only */
+    AS5600_FAST_FILTER_THRESHOLD_6LSB             = 0x01,        /**< 6 lsb */
+    AS5600_FAST_FILTER_THRESHOLD_7LSB             = 0x02,        /**< 7 lsb */
+    AS5600_FAST_FILTER_THRESHOLD_9LSB             = 0x03,        /**< 9 lsb */
+    AS5600_FAST_FILTER_THRESHOLD_10LSB            = 0x07,        /**< 10 lsb */
+    AS5600_FAST_FILTER_THRESHOLD_18LSB            = 0x04,        /**< 18 lsb */
+    AS5600_FAST_FILTER_THRESHOLD_21LSB            = 0x05,        /**< 21 lsb */
+    AS5600_FAST_FILTER_THRESHOLD_24LSB            = 0x06,        /**< 24 lsb */
+} as5600_fast_filter_threshold_t;
+
+/**
+ * @brief as5600 status enumeration definition
+ */
+typedef enum
+{
+    AS5600_STATUS_MD = (1 << 5),        /**< agc minimum gain overflow, magnet too strong */
+    AS5600_STATUS_ML = (1 << 4),        /**< agc maximum gain overflow, magnet too weak */
+    AS5600_STATUS_MH = (1 << 3),        /**< magnet was detected */
+} as5600_status_t;
+
+/**
+ * @brief as5600 burn enumeration definition
+ */
+typedef enum
+{
+    AS5600_BURN_CMD1    = 0x01,        /**< load the actual otp content command 1 */
+    AS5600_BURN_CMD2    = 0x11,        /**< load the actual otp content command 2 */
+    AS5600_BURN_CMD3    = 0x10,        /**< load the actual otp content command 3 */
+    AS5600_BURN_ANGLE   = 0x80,        /**< angle */
+    AS5600_BURN_SETTING = 0x40,        /**< setting */
+} as5600_burn_t;
+
+/**
+ * @brief as5600 handle structure definition
+ */
+typedef struct as5600_handle_s
+{
+    uint8_t (*iic_init)(void);                                                          /**< point to an iic_init function address */
+    uint8_t (*iic_deinit)(void);                                                        /**< point to an iic_deinit function address */
+    uint8_t (*iic_read)(uint8_t addr, uint8_t reg, uint8_t *buf, uint16_t len);         /**< point to an iic_read function address */
+    uint8_t (*iic_write)(uint8_t addr, uint8_t reg, uint8_t *buf, uint16_t len);        /**< point to an iic_write function address */
+    void (*delay_ms)(uint32_t ms);                                                      /**< point to a delay_ms function address */
+    void (*debug_print)(const char *const fmt, ...);                                    /**< point to a debug_print function address */
+    uint8_t inited;                                                                     /**< inited flag */
+} as5600_handle_t;
+
+/**
+ * @brief as5600 information structure definition
+ */
+typedef struct as5600_info_s
+{
+    char chip_name[32];                /**< chip name */
+    char manufacturer_name[32];        /**< manufacturer name */
+    char interface[8];                 /**< chip interface name */
+    float supply_voltage_min_v;        /**< chip min supply voltage */
+    float supply_voltage_max_v;        /**< chip max supply voltage */
+    float max_current_ma;              /**< chip max current */
+    float temperature_min;             /**< chip min operating temperature */
+    float temperature_max;             /**< chip max operating temperature */
+    uint32_t driver_version;           /**< driver version */
+} as5600_info_t;
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup as5600_link_driver as5600 link driver function
+ * @brief    as5600 link driver modules
+ * @ingroup  as5600_driver
+ * @{
+ */
+
+/**
+ * @brief     initialize as5600_handle_t structure
+ * @param[in] HANDLE points to an as5600 handle structure
+ * @param[in] STRUCTURE is as5600_handle_t
+ * @note      none
+ */
+#define DRIVER_AS5600_LINK_INIT(HANDLE, STRUCTURE)           memset(HANDLE, 0, sizeof(STRUCTURE))
+
+/**
+ * @brief     link iic_init function
+ * @param[in] HANDLE points to an as5600 handle structure
+ * @param[in] FUC points to an iic_init function address
+ * @note      none
+ */
+#define DRIVER_AS5600_LINK_IIC_INIT(HANDLE, FUC)             (HANDLE)->iic_init = FUC
+
+/**
+ * @brief     link iic_deinit function
+ * @param[in] HANDLE points to an as5600 handle structure
+ * @param[in] FUC points to an iic_deinit function address
+ * @note      none
+ */
+#define DRIVER_AS5600_LINK_IIC_DEINIT(HANDLE, FUC)           (HANDLE)->iic_deinit = FUC
+
+/**
+ * @brief     link iic_read function
+ * @param[in] HANDLE points to an as5600 handle structure
+ * @param[in] FUC points to an iic_read function address
+ * @note      none
+ */
+#define DRIVER_AS5600_LINK_IIC_READ(HANDLE, FUC)             (HANDLE)->iic_read = FUC
+
+/**
+ * @brief     link iic_write function
+ * @param[in] HANDLE points to an as5600 handle structure
+ * @param[in] FUC points to an iic_write function address
+ * @note      none
+ */
+#define DRIVER_AS5600_LINK_IIC_WRITE(HANDLE, FUC)            (HANDLE)->iic_write = FUC
+
+/**
+ * @brief     link delay_ms function
+ * @param[in] HANDLE points to an as5600 handle structure
+ * @param[in] FUC points to a delay_ms function address
+ * @note      none
+ */
+#define DRIVER_AS5600_LINK_DELAY_MS(HANDLE, FUC)             (HANDLE)->delay_ms = FUC
+
+/**
+ * @brief     link debug_print function
+ * @param[in] HANDLE points to an as5600 handle structure
+ * @param[in] FUC points to a debug_print function address
+ * @note      none
+ */
+#define DRIVER_AS5600_LINK_DEBUG_PRINT(HANDLE, FUC)          (HANDLE)->debug_print = FUC
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup as5600_base_driver as5600 base driver function
+ * @brief    as5600 base driver modules
+ * @ingroup  as5600_driver
+ * @{
+ */
+
+/**
+ * @brief      get chip's information
+ * @param[out] *info points to an as5600 info structure
+ * @return     status code
+ *             - 0 success
+ *             - 2 handle is NULL
+ * @note       none
+ */
+uint8_t as5600_info(as5600_info_t *info);
+
+/**
+ * @brief     initialize the chip
+ * @param[in] *handle points to an as5600 handle structure
+ * @return    status code
+ *            - 0 success
+ *            - 1 iic initialization failed
+ *            - 2 handle is NULL
+ *            - 3 linked functions is NULL
+ * @note      none
+ */
+uint8_t as5600_init(as5600_handle_t *handle);
+
+/**
+ * @brief     close the chip
+ * @param[in] *handle points to an as5600 handle structure
+ * @return    status code
+ *            - 0 success
+ *            - 1 iic deinit failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_deinit(as5600_handle_t *handle);
+
+/**
+ * @brief      read the magnetic angle
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *angle_raw points to a raw angle buffer
+ * @param[out] *deg points to a converted angle buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 read failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_read(as5600_handle_t *handle, uint16_t *angle_raw, float *deg);
+
+/**
+ * @brief      convert the angle to the register raw data
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[in]  deg is the angle
+ * @param[out] *reg points to a register raw buffer
+ * @return     status code
+ *             - 0 success
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_angle_convert_to_register(as5600_handle_t *handle, float deg, uint16_t *reg);
+
+/**
+ * @brief      convert the register raw data to the angle
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[in]  reg is the register raw data
+ * @param[out] *deg points to an angle buffer
+ * @return     status code
+ *             - 0 success
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_angle_convert_to_data(as5600_handle_t *handle, uint16_t reg, float *deg);
+
+/**
+ * @brief     set the start position
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] pos is the start position
+ * @return    status code
+ *            - 0 success
+ *            - 1 set start position failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ *            - 4 pos is over 0xFFF
+ * @note      none
+ */
+uint8_t as5600_set_start_position(as5600_handle_t *handle, uint16_t pos);
+
+/**
+ * @brief      get the start position
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *pos points to a start position buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get start position failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_start_position(as5600_handle_t *handle, uint16_t *pos);
+
+/**
+ * @brief     set the stop position
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] pos is the stop position
+ * @return    status code
+ *            - 0 success
+ *            - 1 set stop position failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ *            - 4 pos is over 0xFFF
+ * @note      none
+ */
+uint8_t as5600_set_stop_position(as5600_handle_t *handle, uint16_t pos);
+
+/**
+ * @brief      get the stop position
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *pos points to a stop position buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get stop position failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_stop_position(as5600_handle_t *handle, uint16_t *pos);
+
+/**
+ * @brief     set the max angle
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] ang is the max angle
+ * @return    status code
+ *            - 0 success
+ *            - 1 set max angle failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ *            - 4 ang is over 0xFFF
+ * @note      none
+ */
+uint8_t as5600_set_max_angle(as5600_handle_t *handle, uint16_t ang);
+
+/**
+ * @brief      get the max angle
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *ang points to a max angle buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get max angle failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_max_angle(as5600_handle_t *handle, uint16_t *ang);
+
+/**
+ * @brief     enable or disable the watch dog
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] enable is a bool value
+ * @return    status code
+ *            - 0 success
+ *            - 1 set watchdog failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_watch_dog(as5600_handle_t *handle, as5600_bool_t enable);
+
+/**
+ * @brief      get the watch dog status
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *enable points to a bool value buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get watchdog failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_watch_dog(as5600_handle_t *handle, as5600_bool_t *enable);
+
+/**
+ * @brief     set the fast filter threshold
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] threshold is the fast filter threshold
+ * @return    status code
+ *            - 0 success
+ *            - 1 set fast filter threshold failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_fast_filter_threshold(as5600_handle_t *handle, as5600_fast_filter_threshold_t threshold);
+
+/**
+ * @brief      get the fast filter threshold
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *threshold points to a fast filter threshold buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get fast filter threshold failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_fast_filter_threshold(as5600_handle_t *handle, as5600_fast_filter_threshold_t *threshold);
+
+/**
+ * @brief     set the slow filter
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] filter is the slow filter
+ * @return    status code
+ *            - 0 success
+ *            - 1 set slow filter failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_slow_filter(as5600_handle_t *handle, as5600_slow_filter_t filter);
+
+/**
+ * @brief      get the slow filter
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *filter points to a slow filter buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get slow filter failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_slow_filter(as5600_handle_t *handle, as5600_slow_filter_t *filter);
+
+/**
+ * @brief     set the pwm frequency
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] freq is the pwm frequency
+ * @return    status code
+ *            - 0 success
+ *            - 1 set pwm frequency failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_pwm_frequency(as5600_handle_t *handle, as5600_pwm_frequency_t freq);
+
+/**
+ * @brief      get the pwm frequency
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *freq points to a pwm frequency buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get pwm frequency failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_pwm_frequency(as5600_handle_t *handle, as5600_pwm_frequency_t *freq);
+
+/**
+ * @brief     set the output stage
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] stage is the output stage
+ * @return    status code
+ *            - 0 success
+ *            - 1 set output stage failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_output_stage(as5600_handle_t *handle, as5600_output_stage_t stage);
+
+/**
+ * @brief      get the output stage
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *stage points to an output stage buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get output stage failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_output_stage(as5600_handle_t *handle, as5600_output_stage_t *stage);
+
+/**
+ * @brief     set the hysteresis
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] hysteresis is the set hysteresis
+ * @return    status code
+ *            - 0 success
+ *            - 1 set hysteresis failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_hysteresis(as5600_handle_t *handle, as5600_hysteresis_t hysteresis);
+
+/**
+ * @brief      get the hysteresis
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *hysteresis points to a hysteresis buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get hysteresis failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_hysteresis(as5600_handle_t *handle, as5600_hysteresis_t *hysteresis);
+
+/**
+ * @brief     set the power mode
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] mode is the power mode
+ * @return    status code
+ *            - 0 success
+ *            - 1 set power mode failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_power_mode(as5600_handle_t *handle, as5600_power_mode_t mode);
+
+/**
+ * @brief      get the power mode
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *mode points to a power mode buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get power mode failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_power_mode(as5600_handle_t *handle, as5600_power_mode_t *mode);
+
+/**
+ * @brief      get the raw angle
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *ang points to an ang buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get raw angle failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_raw_angle(as5600_handle_t *handle, uint16_t *ang);
+
+/**
+ * @brief      get the angle
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *ang points to an ang buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get angle failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_angle(as5600_handle_t *handle, uint16_t *ang);
+
+/**
+ * @brief      get the status
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *status points to a status buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get status failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_status(as5600_handle_t *handle, uint8_t *status);
+
+/**
+ * @brief      get the automatic gain control
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *agc points to an agc buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get agc failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_agc(as5600_handle_t *handle, uint8_t *agc);
+
+/**
+ * @brief      get the magnitude
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[out] *magnitude points to a magnitude buffer
+ * @return     status code
+ *             - 0 success
+ *             - 1 get magnitude failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_magnitude(as5600_handle_t *handle, uint16_t *magnitude);
+
+/**
+ * @brief     set the burn
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] burn is the set command
+ * @return    status code
+ *            - 0 success
+ *            - 1 set burn failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_burn(as5600_handle_t *handle, as5600_burn_t burn);
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup as5600_extend_driver as5600 extend driver function
+ * @brief    as5600 extend driver modules
+ * @ingroup  as5600_driver
+ * @{
+ */
+
+/**
+ * @brief     set the chip register
+ * @param[in] *handle points to an as5600 handle structure
+ * @param[in] reg is the iic register address
+ * @param[in] *buf points to a data buffer
+ * @param[in] len is the data buffer length
+ * @return    status code
+ *            - 0 success
+ *            - 1 write failed
+ *            - 2 handle is NULL
+ *            - 3 handle is not initialized
+ * @note      none
+ */
+uint8_t as5600_set_reg(as5600_handle_t *handle, uint8_t reg, uint8_t *buf, uint16_t len);
+
+/**
+ * @brief      get the chip register
+ * @param[in]  *handle points to an as5600 handle structure
+ * @param[in]  reg is the iic register address
+ * @param[out] *buf points to a data buffer
+ * @param[in]  len is the data buffer length
+ * @return     status code
+ *             - 0 success
+ *             - 1 read failed
+ *             - 2 handle is NULL
+ *             - 3 handle is not initialized
+ * @note       none
+ */
+uint8_t as5600_get_reg(as5600_handle_t *handle, uint8_t reg, uint8_t *buf, uint16_t len);
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/firmware/tinyg/hardware.c
+++ b/firmware/tinyg/hardware.c
@@ -44,6 +44,8 @@
 extern "C"{
 #endif
 
+hwSingleton_t hw;
+
 /*
  * _port_bindings  - bind XMEGA ports to hardware - these changed at board revision 7
  * hardware_init() - lowest level hardware init

--- a/firmware/tinyg/hardware.h
+++ b/firmware/tinyg/hardware.h
@@ -256,7 +256,7 @@ typedef struct hmSingleton {
 	PORT_t *sw_port[MOTORS];		// bindings for switch ports (GPIO2)
 	PORT_t *out_port[MOTORS];		// bindings for output ports (GPIO1)
 } hwSingleton_t;
-hwSingleton_t hw;
+extern hwSingleton_t hw;
 
 /*** function prototypes ***/
 

--- a/firmware/tinyg/json_parser.c
+++ b/firmware/tinyg/json_parser.c
@@ -117,6 +117,7 @@ static stat_t _json_parser_kernal(char_t *str)
 		// propagate the group from previous NV pair (if relevant)
 		if (group[0] != NUL) {
 			strncpy(nv->group, group, GROUP_LEN);	// copy the parent's group to this child
+			nv->group[GROUP_LEN] = '\0';
 		}
 		// validate the token and get the index
 		if ((nv->index = nv_get_index(nv->group, nv->token)) == NO_MATCH) {
@@ -124,6 +125,7 @@ static stat_t _json_parser_kernal(char_t *str)
 		}
 		if ((nv_index_is_group(nv->index)) && (nv_group_is_prefixed(nv->token))) {
 			strncpy(group, nv->token, GROUP_LEN);	// record the group ID
+			group[GROUP_LEN] = '\0';
 		}
 		if ((nv = nv->nx) == NULL)
             return (STAT_JSON_TOO_MANY_PAIRS);      // Not supposed to encounter a NULL
@@ -229,7 +231,8 @@ static stat_t _get_nv_pair(nvObj_t *nv, char_t **pstr, int8_t *depth)
 	for (i=0; true; i++, (*pstr)++) {
 		if (strchr(separators, (int)**pstr) != NULL) {
 			*(*pstr)++ = NUL;
-			strncpy(nv->token, name, TOKEN_LEN+1);			// copy the string to the token
+			strncpy(nv->token, name, TOKEN_LEN);			// copy the string to the token
+			nv->token[TOKEN_LEN] = '\0';
 			break;
 		}
 		if (i == MAX_NAME_CHARS)

--- a/firmware/tinyg/main.c
+++ b/firmware/tinyg/main.c
@@ -40,6 +40,7 @@
 #include <avr/interrupt.h>
 #include "xmega/xmega_interrupts.h"
 #include "xmega/xmega_adc.h"
+#include "xmega/xmega_twi.h"
 #endif // __AVR
 
 #ifdef __ARM
@@ -124,6 +125,7 @@ static void _application_init(void)
 
 	// do these next
 	stepper_init(); 				// stepper subsystem 				- must precede gpio_init()
+	twi_init();						// I2C bus (a.k.a TWI)
 	encoder_init();					// virtual encoders
 	switch_init();					// switches
 //	gpio_init();					// parallel IO

--- a/firmware/tinyg/main.c
+++ b/firmware/tinyg/main.c
@@ -126,7 +126,7 @@ static void _application_init(void)
 	// do these next
 	stepper_init(); 				// stepper subsystem 				- must precede gpio_init()
 	twi_init();						// I2C bus (a.k.a TWI)
-	encoder_init();					// virtual encoders
+	encoder_init();					// encoders (virtual or hardware)
 	switch_init();					// switches
 //	gpio_init();					// parallel IO
 	pwm_init();						// pulse width modulation drivers	- must follow gpio_init()

--- a/firmware/tinyg/settings.h
+++ b/firmware/tinyg/settings.h
@@ -105,10 +105,10 @@
 
 // machine default profiles - choose only one:
 
-#include "settings/settings_default.h"				// Default settings for release
+//#include "settings/settings_default.h"				// Default settings for release
 //#include "settings/settings_cnc3040.h"
 //#include "settings/settings_test.h"					// Settings for testing - not for release
-//#include "settings/settings_openpnp.h"				// OpenPnP
+#include "settings/settings_openpnp.h"				// OpenPnP
 //#include "settings/settings_othermill.h"				// OMC OtherMill
 //#include "settings/settings_probotixV90.h"			// Probotix Fireball V90
 //#include "settings/settings_shapeoko2.h"				// Shapeoko2 - standard kit

--- a/firmware/tinyg/settings.h
+++ b/firmware/tinyg/settings.h
@@ -105,10 +105,10 @@
 
 // machine default profiles - choose only one:
 
-//#include "settings/settings_default.h"				// Default settings for release
+#include "settings/settings_default.h"				// Default settings for release
 //#include "settings/settings_cnc3040.h"
 //#include "settings/settings_test.h"					// Settings for testing - not for release
-#include "settings/settings_openpnp.h"				// OpenPnP
+//#include "settings/settings_openpnp.h"				// OpenPnP
 //#include "settings/settings_othermill.h"				// OMC OtherMill
 //#include "settings/settings_probotixV90.h"			// Probotix Fireball V90
 //#include "settings/settings_shapeoko2.h"				// Shapeoko2 - standard kit

--- a/firmware/tinyg/switch.c
+++ b/firmware/tinyg/switch.c
@@ -48,6 +48,8 @@
 #include "canonical_machine.h"
 #include "text_parser.h"
 
+struct swStruct sw;
+
 static void _switch_isr_helper(uint8_t sw_num);
 
 /*

--- a/firmware/tinyg/switch.h
+++ b/firmware/tinyg/switch.h
@@ -146,7 +146,7 @@ struct swStruct {								// switch state
 	volatile uint8_t debounce[NUM_SWITCHES];	// switch debouncer state machine - see swDebounce
 	volatile int8_t count[NUM_SWITCHES];		// deglitching and lockout counter
 };
-struct swStruct sw;
+extern struct swStruct sw;
 
 //*** Structures from new-style switch code --- NOT YET FOLDED IN ***//
 

--- a/firmware/tinyg/xio.c
+++ b/firmware/tinyg/xio.c
@@ -88,6 +88,12 @@ typedef struct xioSingleton {
 } xioSingleton_t;
 xioSingleton_t xio;
 
+// Static structure allocations
+xioDev_t 		ds[XIO_DEV_COUNT];			// allocate top-level dev structs
+xioUsart_t 		us[XIO_DEV_USART_COUNT];	// USART extended IO structs
+xioSpi_t 		spi[XIO_DEV_SPI_COUNT];		// SPI extended IO structs
+xioFile_t 		fs[XIO_DEV_FILE_COUNT];		// FILE extended IO structs
+
 /********************************************************************************
  * XIO Initializations, Resets and Assertions
  */

--- a/firmware/tinyg/xio.h
+++ b/firmware/tinyg/xio.h
@@ -163,11 +163,10 @@ typedef void (*x_flow_t)(xioDev_t *d);
 #include "xio/xio_usart.h"
 #include "xio/xio_spi.h"
 
-// Static structure allocations
-xioDev_t 		ds[XIO_DEV_COUNT];			// allocate top-level dev structs
-xioUsart_t 		us[XIO_DEV_USART_COUNT];	// USART extended IO structs
-xioSpi_t 		spi[XIO_DEV_SPI_COUNT];		// SPI extended IO structs
-xioFile_t 		fs[XIO_DEV_FILE_COUNT];		// FILE extended IO structs
+extern xioDev_t 		ds[XIO_DEV_COUNT];			// allocate top-level dev structs
+extern xioUsart_t 		us[XIO_DEV_USART_COUNT];	// USART extended IO structs
+extern xioSpi_t 		spi[XIO_DEV_SPI_COUNT];		// SPI extended IO structs
+extern xioFile_t 		fs[XIO_DEV_FILE_COUNT];		// FILE extended IO structs
 extern struct controllerSingleton tg;		// needed by init() for default source
 
 /*************************************************************************

--- a/firmware/tinyg/xmega/xmega_twi.c
+++ b/firmware/tinyg/xmega/xmega_twi.c
@@ -1,0 +1,249 @@
+/*
+ * File TWI.c
+ * Author: Tycho J�bsis
+ * Date: 13-02-2021
+ */ 
+
+
+/*
+*	MIT License
+*
+*	Copyright (c) 2021 TychoJ
+*
+*	Permission is hereby granted, free of charge, to any person obtaining a copy
+*	of this software and associated documentation files (the "Software"), to deal
+*	in the Software without restriction, including without limitation the rights
+*	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*	copies of the Software, and to permit persons to whom the Software is
+*	furnished to do so, subject to the following conditions:
+*
+*	The above copyright notice and this permission notice shall be included in all
+*	copies or substantial portions of the Software.
+*
+*	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+*	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+*	SOFTWARE.
+*/
+
+#include <avr/io.h>
+#include <util/delay.h>
+#include "xmega_twi.h"
+
+void set_baud(TWI_t *twi, uint32_t TWI_speed){
+	twi->MASTER.BAUD = TWI_BAUD(F_CPU, TWI_speed);
+}
+
+void twi_init(TWI_t *twi, uint32_t TWI_speed, uint8_t timeout){
+	set_baud(twi, TWI_speed);
+	set_acknowledge(twi, ACK);
+	twi->MASTER.CTRLA = TWI_MASTER_ENABLE_bm;
+	set_timeout(twi, timeout);	
+}
+
+void disable_TWI(TWI_t *twi){
+	twi->MASTER.CTRLA = (0 << TWI_MASTER_ENABLE_bp);
+}
+
+void set_timeout(TWI_t *twi, uint8_t time_out){
+	switch(time_out){
+		case TIMEOUT_DIS:
+		twi->MASTER.CTRLB = TIMEOUT_DIS;
+		twi->MASTER.STATUS = TWI_MASTER_BUSSTATE_IDLE_gc;
+		break;
+		
+		case TIMEOUT_50US:
+		twi->MASTER.CTRLB = TIMEOUT_50US;
+		twi->MASTER.STATUS = TWI_MASTER_BUSSTATE_UNKNOWN_gc;
+		break;
+		
+		case TIMEOUT_100US:
+		twi->MASTER.CTRLB = TIMEOUT_100US;
+		twi->MASTER.STATUS = TWI_MASTER_BUSSTATE_UNKNOWN_gc;
+		break;
+		
+		case TIMEOUT_200US:
+		twi->MASTER.CTRLB = TIMEOUT_200US;
+		twi->MASTER.STATUS = TWI_MASTER_BUSSTATE_UNKNOWN_gc;
+		break;
+		
+		default:
+		twi->MASTER.CTRLB = TIMEOUT_DIS;
+		twi->MASTER.STATUS = TWI_MASTER_BUSSTATE_IDLE_gc;
+		break;
+	}
+}
+
+void set_acknowledge(TWI_t *twi, uint8_t ack){
+	(ack == ACK) ? (twi->MASTER.CTRLC = (0 << 2)) : (twi->MASTER.CTRLC = (1 << 2));
+}
+
+uint8_t bus_state(TWI_t *twi){
+	uint8_t ret = twi->MASTER.STATUS;
+	//ret = (000000 << 2);
+	if( (ret & TWI_MASTER_BUSSTATE_gm) == TWI_MASTER_BUSSTATE_UNKNOWN_gc ) return UNKNOWN_BUS_STATE;
+	if( (ret & TWI_MASTER_BUSSTATE_gm) != TWI_MASTER_BUSSTATE_IDLE_gc ) return BUS_NOT_IN_USE;
+	if( (ret & TWI_MASTER_BUSSTATE_gm) != TWI_MASTER_BUSSTATE_IDLE_gc ) return OWNER_OF_BUS;
+	if( (ret & TWI_MASTER_BUSSTATE_gm) != TWI_MASTER_BUSSTATE_IDLE_gc ) return BUS_IN_USE;
+	return 1;
+}
+
+void set_bus_state_TWI(TWI_t *twi, uint8_t state){
+	twi->MASTER.STATUS = state;
+}
+
+uint8_t wait_till_send(TWI_t *twi, uint8_t rw){
+	uint8_t send_suc = 0;
+	uint16_t time_passed = 0;
+	
+	while ( !send_suc){
+		
+		if(twi->MASTER.STATUS & (TWI_MASTER_WIF_bm << rw)) send_suc = 1;
+		
+		if(time_passed > 1000) return DATA_NOT_SEND;
+		_delay_us(1);		
+		time_passed++;
+	}
+	return TWI_STATUS_OK;
+}
+
+uint8_t wait_till_received(TWI_t *twi, uint8_t rw){
+	if(wait_till_send(twi, rw) == TWI_STATUS_OK) return TWI_STATUS_OK;
+	return DATA_NOT_RECEIVED;
+}
+
+uint8_t start_TWI(TWI_t *twi, uint8_t addr, uint8_t rw){
+	
+	if(bus_state(twi) != BUS_NOT_IN_USE) return bus_state(twi);
+	
+	if( !( (rw == READ) || (rw == WRITE) ) ) return INVALID_RW;
+	
+	twi->MASTER.ADDR = (addr << 1) | rw;	//send slave address
+	if(wait_till_send(twi, rw) == DATA_NOT_SEND) return DATA_NOT_SEND; // wait until sent
+	
+	//when RXACK is 0 an ACK has been received
+	if(twi->MASTER.STATUS & TWI_MASTER_RXACK_bm){
+		stop_TWI(twi);
+		return NACK;
+		} 
+	
+	return ACK;
+}
+
+uint8_t repeated_start_TWI(TWI_t *twi, uint8_t addr, uint8_t rw){
+	if(bus_state(twi) != OWNER_OF_BUS) return bus_state(twi);
+	
+	if( !( (rw == READ) || (rw == WRITE) ) ) return INVALID_RW;
+	twi->MASTER.ADDR = (addr << 1) | rw;
+	
+	wait_till_send(twi, rw);
+	
+	
+	//when RXACK is 0 an ACK has been received
+	if(twi->MASTER.STATUS & TWI_MASTER_RXACK_bm) return NACK;
+	
+	return TWI_STATUS_OK;
+}
+
+void stop_TWI(TWI_t *twi){
+	twi->MASTER.CTRLC = TWI_MASTER_CMD_STOP_gc;
+	
+}
+
+uint8_t send_TWI(TWI_t *twi, uint8_t data){
+	twi->MASTER.DATA = data;
+	
+	if( wait_till_send(twi, WRITE) == DATA_NOT_SEND) return DATA_NOT_SEND;
+	
+	//when RXACK is 0 an ACK has been received
+	if(twi->MASTER.STATUS & TWI_MASTER_RXACK_bm) return NACK;
+	
+	return ACK;
+}
+
+uint8_t read_TWI(TWI_t *twi, uint8_t *data, uint8_t go_on){
+	if(wait_till_received(twi, READ) == DATA_NOT_RECEIVED) return DATA_NOT_RECEIVED;
+	(*data) = twi->MASTER.DATA;
+	 twi->MASTER.CTRLC = ((go_on == ACK) ? TWI_MASTER_CMD_RECVTRANS_gc :        // send ack (go on) or
+	 TWI_MASTER_ACKACT_bm|TWI_MASTER_CMD_STOP_gc); //     nack (and stop)
+	return TWI_STATUS_OK;
+}
+
+uint8_t send_8bit_TWI(TWI_t *twi, uint8_t addr, uint8_t data){
+	uint8_t err;
+	
+	err = start_TWI(twi, addr, WRITE);
+	
+	//check for errors
+	if(err == BUS_IN_USE) return BUS_IN_USE;
+	if(err == NACK) return NACK;
+	
+	err = send_TWI(twi, data);
+	
+	//check for errors
+	if(err == DATA_NOT_SEND) return DATA_NOT_SEND;
+	if(err == NACK) return NACK;
+	
+	stop_TWI(twi);
+	
+	return TWI_STATUS_OK;	
+}
+
+uint8_t write_8bit_register_TWI(TWI_t *twi, uint8_t addr, uint8_t data, uint8_t reg){
+	uint8_t err;
+	
+	err = start_TWI(twi, addr, WRITE);
+	
+	//check for errors
+	if(err == BUS_IN_USE) return BUS_IN_USE;
+	if(err == NACK) return NACK;
+	
+	err = send_TWI(twi, reg);
+	
+	//check for errors
+	if(err == DATA_NOT_SEND) return DATA_NOT_SEND;
+	if(err == NACK) return NACK;
+	
+	err = send_TWI(twi, data);
+	
+	//check for errors
+	if(err == DATA_NOT_SEND) return DATA_NOT_SEND;
+	if(err == NACK) return NACK;
+	
+	stop_TWI(twi);
+	
+	return TWI_STATUS_OK;
+}
+
+uint8_t read_8bit_register_TWI(TWI_t *twi, uint8_t addr, uint8_t *data, uint8_t reg){
+	uint8_t err;
+	
+	err = start_TWI(twi, addr, WRITE);
+	
+	//check for errors
+	if(err == BUS_IN_USE) return BUS_IN_USE;
+	if(err == NACK) return NACK;
+	
+	err = send_TWI(twi, reg);
+	
+	//check for errors
+	if(err == DATA_NOT_SEND) return DATA_NOT_SEND;
+	if(err == NACK) return NACK;
+	
+	//err = repeated_start_TWI(twi, addr, READ);
+	twi->MASTER.ADDR = (addr << 1) | READ;
+	while( ! (twi->MASTER.STATUS & (TWI_MASTER_WIF_bm << READ)) );  // wait until sent
+	
+	//check for errors
+	if(err == BUS_IN_USE) return BUS_IN_USE;
+	if(err == NACK) return NACK;
+	
+	err = read_TWI(twi, data, NACK);
+	
+	if(err == DATA_NOT_RECEIVED) return DATA_NOT_RECEIVED; 
+	
+	return TWI_STATUS_OK;
+}

--- a/firmware/tinyg/xmega/xmega_twi.c
+++ b/firmware/tinyg/xmega/xmega_twi.c
@@ -37,7 +37,14 @@ void set_baud(TWI_t *twi, uint32_t TWI_speed){
 	twi->MASTER.BAUD = TWI_BAUD(F_CPU, TWI_speed);
 }
 
-void twi_init(TWI_t *twi, uint32_t TWI_speed, uint8_t timeout){
+/// "Reasonable defaults" here include settings for TinyG v8 board
+/// This TWI mod involves physically getting rid of CTS/RTS signals
+/// in favor of this I2C compatible (TWI) bus.
+void twi_init() {
+	enable_TWI(&TWIC, BAUD_100K, TIMEOUT_DIS);
+}
+
+void enable_TWI(TWI_t *twi, uint32_t TWI_speed, uint8_t timeout){
 	set_baud(twi, TWI_speed);
 	set_acknowledge(twi, ACK);
 	twi->MASTER.CTRLA = TWI_MASTER_ENABLE_bm;

--- a/firmware/tinyg/xmega/xmega_twi.c
+++ b/firmware/tinyg/xmega/xmega_twi.c
@@ -4,6 +4,8 @@
  * Date: 13-02-2021
  */ 
 
+// Interesting software bit-banging alternative that might not require
+// hardware mods to the TinyG v8 board: https://github.com/dvdfreitag/xmega-software-twi/tree/master
 
 /*
 *	MIT License

--- a/firmware/tinyg/xmega/xmega_twi.h
+++ b/firmware/tinyg/xmega/xmega_twi.h
@@ -73,6 +73,9 @@
 //set the baud rate of a TWI module
 void set_baud(TWI_t *twi, uint32_t TWI_speed);
 
+// initialises TWI module with "reasonable defaults"
+void twi_init();
+
 //enables a TWI module
 //TWI_speed is used to calculate the baud rate
 //timeout: if you are the only master you should use TIMEOUT_DIS

--- a/firmware/tinyg/xmega/xmega_twi.h
+++ b/firmware/tinyg/xmega/xmega_twi.h
@@ -1,0 +1,141 @@
+/*
+ * File TWI.h
+ * Author: Tycho J�bsis
+ * Date: 13-02-2021
+ */ 
+
+/*
+*	MIT License
+*
+*	Copyright (c) 2021 TychoJ
+*
+*	Permission is hereby granted, free of charge, to any person obtaining a copy
+*	of this software and associated documentation files (the "Software"), to deal
+*	in the Software without restriction, including without limitation the rights
+*	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*	copies of the Software, and to permit persons to whom the Software is
+*	furnished to do so, subject to the following conditions:
+*
+*	The above copyright notice and this permission notice shall be included in all
+*	copies or substantial portions of the Software.
+*
+*	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+*	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+*	SOFTWARE.
+*/
+
+
+#include <avr/io.h>
+
+#ifndef F_CPU
+#define F_CPU 2000000UL
+#endif
+
+#ifndef TWI_H_
+#define TWI_H_
+
+#define BAUD_100K        100000UL
+#define BAUD_400K        400000UL
+
+#define TIMEOUT_DIS   TWI_MASTER_TIMEOUT_DISABLED_gc
+#define TIMEOUT_50US  TWI_MASTER_TIMEOUT_50US_gc
+#define TIMEOUT_100US TWI_MASTER_TIMEOUT_100US_gc
+#define TIMEOUT_200US TWI_MASTER_TIMEOUT_200US_gc
+
+#define	UNKNOWN_BUS_STATE	0
+#define	BUS_NOT_IN_USE		1
+#define	OWNER_OF_BUS		2
+#define	BUS_IN_USE			3
+
+#define	UNKNOWN_BUS_STATE_GR	TWI_MASTER_BUSSTATE_UNKNOWN_gc
+#define	BUS_NOT_IN_USE_GR		TWI_MASTER_BUSSTATE_IDLE_gc
+#define	OWNER_OF_BUS_GR			TWI_MASTER_BUSSTATE_OWNER_gc
+#define	BUS_IN_USE_GR			TWI_MASTER_BUSSTATE_BUSY_gc
+
+#define INVALID_RW	4
+
+#define WRITE 0 
+#define READ  1
+
+#define NACK 0
+#define ACK	 1
+#define DATA_NOT_SEND 10
+#define DATA_NOT_RECEIVED 7
+#define TWI_STATUS_OK 5
+
+//inline function to calculate the baud value
+#define TWI_BAUD(F_SYS, F_TWI)   ((F_SYS / (2 * F_TWI)) - 5)
+
+//set the baud rate of a TWI module
+void set_baud(TWI_t *twi, uint32_t TWI_speed);
+
+//enables a TWI module
+//TWI_speed is used to calculate the baud rate
+//timeout: if you are the only master you should use TIMEOUT_DIS
+void enable_TWI(TWI_t *twi, uint32_t TWI_speed, uint8_t timeout);
+
+//disables a TWI module
+void disable_TWI(TWI_t *twi);
+
+//time in us after which it's assumed the TWI bus is free
+
+// disabled(normally used for i2c), 50us, 100us, 200us  
+void set_timeout(TWI_t *twi, uint8_t time_out);
+
+//selects if ACK or NACK will be used
+void set_acknowledge(TWI_t *twi, uint8_t ack);
+
+//returns in what state the bus is
+uint8_t bus_state(TWI_t *twi);  
+
+//function used for setting the bus state
+void set_bus_state_TWI(TWI_t *twi, uint8_t state);
+
+uint8_t wait_till_send(TWI_t *twi, uint8_t rw);
+
+uint8_t wait_till_received(TWI_t *twi, uint8_t rw);
+
+//issues an start condition and send an address
+//returns 1 if an acknowledge is received
+//returns 0 if a not acknowledge is received
+//returns 3 if the bus is not free
+uint8_t start_TWI(TWI_t *twi, uint8_t addr, uint8_t rw);
+
+uint8_t repeated_start_TWI(TWI_t *twi, uint8_t addr, uint8_t rw);
+
+//issues a stop condition
+void stop_TWI(TWI_t *twi);
+
+//internal function used for sending data
+uint8_t send_TWI(TWI_t *twi, uint8_t data);
+
+//internal function used to read data
+//twi for what twi module
+//data pointer to store read data
+//go_on to continue or stop reading data
+//returns 7 when data is not received
+//returns 5 if data is received and no errors have occurred
+//go_on 1 continue 0 stop reading
+uint8_t read_TWI(TWI_t *twi, uint8_t *data, uint8_t go_on);
+
+//send 8bits to the address 
+uint8_t send_8bit_TWI(TWI_t *twi, uint8_t addr, uint8_t data);
+
+//twi is the TWI port
+//addr is the address of the TWI device were you want to write to a register
+//data is the data that you want to write in the register
+//reg is the register to which you want to write the data
+uint8_t write_8bit_register_TWI(TWI_t *twi, uint8_t addr, uint8_t data, uint8_t reg);
+
+//twi is the TWI port
+//addr is the address of the TWI device were you want to read a register
+//data is the variable where you want to store the data 
+//reg is the register you want to read data from
+uint8_t read_8bit_register_TWI(TWI_t *twi, uint8_t addr, uint8_t *data, uint8_t reg);
+
+
+#endif /* TWI_H_ */


### PR DESCRIPTION
This PR builds on top of the excellent @ian-arkver work on PR #3. I hope Ian's PR gets merged (after merging https://github.com/ian-arkver/TinyG/pull/1) and then I can rebase this one accordingly. This is a WIP that will eventually add:

* Tuning for VSCode's IntelliSense syntax highlighting for AVR development (thanks https://bytecoil.com/avr-programming/vscode-avr-programming-setup/).
* TWI(C) definitions (thanks https://github.com/TychoJ/Xmega-TWI/tree/master). Modifications will have to supplant RTS/CTS pins to have an I2C bus available (so modifications will be required on the TinyG v8 board). Those mods will be documented in the future.
* AS5600 encoder driver (thanks https://github.com/libdriver/as5600).